### PR TITLE
Issue #1: update php and remove deprecated commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Antidot Doctrine Integration
 
+Integration library between [Doctrine ORM]() and [Antidot Framework]() using [dasprid/container-interop-doctrine]() factories.
+
+## Install
+
+Install using [composer]().
+
+```bash
+composer require antidot-fw/doctrine
+```
+
+
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 Integration library between [Doctrine ORM](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/index.html) and 
 [Antidot Framework](https://antidotfw.io/#/framework/getting-started) using [Roave PSR-11 Doctrine factories](https://github.com/Roave/psr-container-doctrine).
 
+## Requirements
+
+* PHP >= 7.2.13 for 0.0.x
+* PHP >= 7.4.0 for current
+
 ## Install
 
 Install using [composer]().

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Antidot Doctrine Integration
 
-Integration library between [Doctrine ORM]() and [Antidot Framework]() using [dasprid/container-interop-doctrine]() factories.
+Integration library between [Doctrine ORM](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/index.html) and 
+[Antidot Framework](https://antidotfw.io/#/framework/getting-started) using [Roave PSR-11 Doctrine factories](https://github.com/Roave/psr-container-doctrine).
 
 ## Install
 
@@ -10,5 +11,25 @@ Install using [composer]().
 composer require antidot-fw/doctrine
 ```
 
+## Default Config fot Antidot Framework Starter
+
+Doctrine integration requires a minimum config to work, by default it is configured with [the `SimplifiedYamlDriver`](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/reference/yaml-mapping.html#simplified-yaml-driver). 
+When you need more complex or more custom config you can implement it without ani issues following [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/index.html).
+
+```yaml
+# Example using PDOSqliteDriver, and allocating yaml files at `config/doctrine` 
+# directory for `App\Domain\Model` namespace.
+parameters:
+  doctrine:
+    connection:
+      orm_default:
+        driver_class: Doctrine\DBAL\Driver\PDOSqlite\Driver
+        params:
+          path: var/database.sqlite
+    driver:
+      orm_default:
+        paths:
+          config/doctrine: App\Domain\Model
+```
 
 

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,8 @@
     "require": {
         "php": "^7.4.3",
         "antidot-fw/cli": "^1.0.0",
-        "dasprid/container-interop-doctrine": "^1.1.0",
-        "doctrine/migrations": "^2.2",
-        "psr/container": "^1.0.0"
+        "psr/container": "^1.0.0",
+        "roave/psr-container-doctrine": "^2.2"
     },
     "require-dev": {
         "doctrine/migrations": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,11 @@
         }
     ],
     "require": {
-        "php": "^7.2.13",
+        "php": "^7.4.3",
         "antidot-fw/cli": "^1.0.0",
-        "psr/container": "^1.0.0",
-        "dasprid/container-interop-doctrine": "^1.1.0"
+        "dasprid/container-interop-doctrine": "^1.1.0",
+        "doctrine/migrations": "^2.2",
+        "psr/container": "^1.0.0"
     },
     "require-dev": {
         "doctrine/migrations": "^2.0",

--- a/src/Container/AntidotCliDoctrineDelegatorFactory.php
+++ b/src/Container/AntidotCliDoctrineDelegatorFactory.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace Antidot\Persistence\Doctrine\Container;
 
 use Antidot\Cli\Application\Console;
-use Doctrine\Migrations\Tools\Console\Helper\ConfigurationHelper;
-use Doctrine\ORM\EntityManager;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Container/Config/ConfigProvider.php
+++ b/src/Container/Config/ConfigProvider.php
@@ -9,8 +9,6 @@ use Antidot\Persistence\Doctrine\Container\AntidotCliDoctrineDelegatorFactory;
 use ContainerInteropDoctrine\ConnectionFactory;
 use ContainerInteropDoctrine\EntityManagerFactory;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\PDOSqlite\Driver;
-use Doctrine\DBAL\Tools\Console\Command\ImportCommand;
 use Doctrine\DBAL\Tools\Console\Command\ReservedWordsCommand;
 use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
 use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
@@ -31,12 +29,9 @@ use Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand;
 use Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand;
 use Doctrine\ORM\Tools\Console\Command\ClearCache\QueryRegionCommand;
 use Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand;
-use Doctrine\ORM\Tools\Console\Command\ConvertDoctrine1SchemaCommand;
 use Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand;
 use Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand;
-use Doctrine\ORM\Tools\Console\Command\GenerateEntitiesCommand;
 use Doctrine\ORM\Tools\Console\Command\GenerateProxiesCommand;
-use Doctrine\ORM\Tools\Console\Command\GenerateRepositoriesCommand;
 use Doctrine\ORM\Tools\Console\Command\InfoCommand;
 use Doctrine\ORM\Tools\Console\Command\MappingDescribeCommand;
 use Doctrine\ORM\Tools\Console\Command\RunDqlCommand;
@@ -55,7 +50,7 @@ class ConfigProvider
                     'doctrine.entity_manager.orm_default' => EntityManagerFactory::class,
                     'doctrine.connection.orm_default' => [ConnectionFactory::class, 'orm_default'],
                 ],
-                'aliases' => [
+                'services' => [
                     EntityManagerInterface::class => 'doctrine.entity_manager.orm_default',
                     Connection::class => 'doctrine.connection.orm_default',
                 ],
@@ -63,7 +58,6 @@ class ConfigProvider
             'console' => [
                 'commands' => [
                     // DBAL Commands
-                    'dbal:import' => ImportCommand::class,
                     'dbal:reserved-words' => ReservedWordsCommand::class,
                     'dbal:run-sql' => RunSqlCommand::class,
 
@@ -78,9 +72,6 @@ class ConfigProvider
                     'orm:schema-tool:update' => UpdateCommand::class,
                     'orm:schema-tool:drop' => DropCommand::class,
                     'orm:ensure-production-settings' => EnsureProductionSettingsCommand::class,
-                    'orm:convert-d1-schema' => ConvertDoctrine1SchemaCommand::class,
-                    'orm:generate-repositories' => GenerateRepositoriesCommand::class,
-                    'orm:generate-entities' => GenerateEntitiesCommand::class,
                     'orm:generate-proxies' => GenerateProxiesCommand::class,
                     'orm:convert-mapping' => ConvertMappingCommand::class,
                     'orm:run-dql' => RunDqlCommand::class,
@@ -98,49 +89,43 @@ class ConfigProvider
                     'migrations:up-to-date' => UpToDateCommand::class,
                     'migrations:diff' => DiffCommand::class,
                 ],
-                'dependencies' => [
-                    'invokables' => [
-                        // DBAL Commands
-                        ImportCommand::class => ImportCommand::class,
-                        ReservedWordsCommand::class => ReservedWordsCommand::class,
-                        RunSqlCommand::class => RunSqlCommand::class,
+                'services' => [
+                    // DBAL Commands
+                    ReservedWordsCommand::class => ReservedWordsCommand::class,
+                    RunSqlCommand::class => RunSqlCommand::class,
 
-                        // ORM Commands
-                        CollectionRegionCommand::class => CollectionRegionCommand::class,
-                        EntityRegionCommand::class => EntityRegionCommand::class,
-                        MetadataCommand::class => MetadataCommand::class,
-                        QueryCommand::class => QueryCommand::class,
-                        QueryRegionCommand::class => QueryRegionCommand::class,
-                        ResultCommand::class => ResultCommand::class,
-                        CreateCommand::class => CreateCommand::class,
-                        UpdateCommand::class => UpdateCommand::class,
-                        DropCommand::class => DropCommand::class,
-                        EnsureProductionSettingsCommand::class => EnsureProductionSettingsCommand::class,
-                        ConvertDoctrine1SchemaCommand::class => ConvertDoctrine1SchemaCommand::class,
-                        GenerateRepositoriesCommand::class => GenerateRepositoriesCommand::class,
-                        GenerateEntitiesCommand::class => GenerateEntitiesCommand::class,
-                        GenerateProxiesCommand::class => GenerateProxiesCommand::class,
-                        ConvertMappingCommand::class => ConvertMappingCommand::class,
-                        RunDqlCommand::class => RunDqlCommand::class,
-                        ValidateSchemaCommand::class => ValidateSchemaCommand::class,
-                        InfoCommand::class => InfoCommand::class,
-                        MappingDescribeCommand::class => MappingDescribeCommand::class,
-                        DumpSchemaCommand::class => DumpSchemaCommand::class,
-                        ExecuteCommand::class => ExecuteCommand::class,
-                        GenerateCommand::class => GenerateCommand::class,
-                        LatestCommand::class => LatestCommand::class,
-                        MigrateCommand::class => MigrateCommand::class,
-                        RollupCommand::class => RollupCommand::class,
-                        StatusCommand::class => StatusCommand::class,
-                        VersionCommand::class => VersionCommand::class,
-                        UpToDateCommand::class => UpToDateCommand::class,
-                        DiffCommand::class => DiffCommand::class,
-                    ],
-                    'delegators' => [
-                        Console::class => [
-                            AntidotCliDoctrineDelegatorFactory::class
-                        ]
-                    ],
+                    // ORM Commands
+                    CollectionRegionCommand::class => CollectionRegionCommand::class,
+                    EntityRegionCommand::class => EntityRegionCommand::class,
+                    MetadataCommand::class => MetadataCommand::class,
+                    QueryCommand::class => QueryCommand::class,
+                    QueryRegionCommand::class => QueryRegionCommand::class,
+                    ResultCommand::class => ResultCommand::class,
+                    CreateCommand::class => CreateCommand::class,
+                    UpdateCommand::class => UpdateCommand::class,
+                    DropCommand::class => DropCommand::class,
+                    EnsureProductionSettingsCommand::class => EnsureProductionSettingsCommand::class,
+                    GenerateProxiesCommand::class => GenerateProxiesCommand::class,
+                    ConvertMappingCommand::class => ConvertMappingCommand::class,
+                    RunDqlCommand::class => RunDqlCommand::class,
+                    ValidateSchemaCommand::class => ValidateSchemaCommand::class,
+                    InfoCommand::class => InfoCommand::class,
+                    MappingDescribeCommand::class => MappingDescribeCommand::class,
+                    DumpSchemaCommand::class => DumpSchemaCommand::class,
+                    ExecuteCommand::class => ExecuteCommand::class,
+                    GenerateCommand::class => GenerateCommand::class,
+                    LatestCommand::class => LatestCommand::class,
+                    MigrateCommand::class => MigrateCommand::class,
+                    RollupCommand::class => RollupCommand::class,
+                    StatusCommand::class => StatusCommand::class,
+                    VersionCommand::class => VersionCommand::class,
+                    UpToDateCommand::class => UpToDateCommand::class,
+                    DiffCommand::class => DiffCommand::class,
+                ],
+                'delegators' => [
+                    Console::class => [
+                        AntidotCliDoctrineDelegatorFactory::class
+                    ]
                 ],
             ],
             'doctrine' => [

--- a/src/Container/Config/ConfigProvider.php
+++ b/src/Container/Config/ConfigProvider.php
@@ -49,14 +49,17 @@ class ConfigProvider
     public function __invoke(): array
     {
         return [
-            'dependencies' => [
-                'factories' => [
-                    'doctrine.entity_manager.orm_default' => EntityManagerFactory::class,
-                    'doctrine.connection.orm_default' => [ConnectionFactory::class, 'orm_default'],
-                ],
-                'services' => [
-                    EntityManagerInterface::class => 'doctrine.entity_manager.orm_default',
-                    Connection::class => 'doctrine.connection.orm_default',
+            'factories' => [
+                'doctrine.entity_manager.orm_default' => EntityManagerFactory::class,
+                'doctrine.connection.orm_default' => [ConnectionFactory::class, 'orm_default'],
+            ],
+            'services' => [
+                EntityManagerInterface::class => 'doctrine.entity_manager.orm_default',
+                Connection::class => 'doctrine.connection.orm_default',
+            ],
+            'delegators' => [
+                Console::class => [
+                    AntidotCliDoctrineDelegatorFactory::class
                 ],
             ],
             'console' => [
@@ -125,11 +128,6 @@ class ConfigProvider
                     VersionCommand::class => VersionCommand::class,
                     UpToDateCommand::class => UpToDateCommand::class,
                     DiffCommand::class => DiffCommand::class,
-                ],
-                'delegators' => [
-                    Console::class => [
-                        AntidotCliDoctrineDelegatorFactory::class
-                    ]
                 ],
             ],
             'doctrine' => [

--- a/src/Container/Config/ConfigProvider.php
+++ b/src/Container/Config/ConfigProvider.php
@@ -131,9 +131,6 @@ class ConfigProvider
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
-//                        'driver_class' => Driver::class,
-//                        'params' => [
-//                        ],
                     ],
                 ],
                 'driver' => [

--- a/src/Container/Config/ConfigProvider.php
+++ b/src/Container/Config/ConfigProvider.php
@@ -42,6 +42,10 @@ use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand;
 
 class ConfigProvider
 {
+    public const CONNECTION_ALIAS_PATTERN = 'doctrine.entity_manager.%s';
+    public const DEFAULT_CONNECTION = 'orm_default';
+    public const CONTAINER_EXCEPTION_MESSAGE_PATTER = 'The `%s` class must be configured in the DI container.';
+
     public function __invoke(): array
     {
         return [
@@ -130,11 +134,11 @@ class ConfigProvider
             ],
             'doctrine' => [
                 'connection' => [
-                    'orm_default' => [
+                    self::DEFAULT_CONNECTION => [
                     ],
                 ],
                 'driver' => [
-                    'orm_default' => [
+                    self::DEFAULT_CONNECTION => [
                         'class' => SimplifiedYamlDriver::class,
                         'cache' => 'array',
                         'paths' => [

--- a/src/Container/DoctrineCliHelperSetFactory.php
+++ b/src/Container/DoctrineCliHelperSetFactory.php
@@ -4,16 +4,28 @@ declare(strict_types=1);
 
 namespace Antidot\Persistence\Doctrine\Container;
 
+use Antidot\Persistence\Doctrine\Container\Config\ConfigProvider;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\ConsoleRunner;
 use Psr\Container\ContainerInterface;
+use RuntimeException;
 use Symfony\Component\Console\Helper\HelperSet;
 
 class DoctrineCliHelperSetFactory
 {
-    public function __invoke(ContainerInterface $container, string $connectionName): HelperSet
-    {
-        return ConsoleRunner::createHelperSet(
-            $container->get('doctrine.entity_manager.' . $connectionName)
-        );
+    public function __invoke(
+        ContainerInterface $container,
+        string $connectionName = ConfigProvider::DEFAULT_CONNECTION
+    ): HelperSet {
+        $entityManager = $container->get(sprintf(ConfigProvider::CONNECTION_ALIAS_PATTERN, $connectionName));
+
+        if (false === $entityManager instanceof EntityManagerInterface) {
+            throw new RuntimeException(sprintf(
+                ConfigProvider::CONTAINER_EXCEPTION_MESSAGE_PATTER,
+                EntityManagerInterface::class
+            ));
+        }
+
+        return ConsoleRunner::createHelperSet($entityManager);
     }
 }

--- a/src/Container/EntityRepositoryFactory.php
+++ b/src/Container/EntityRepositoryFactory.php
@@ -4,14 +4,24 @@ declare(strict_types=1);
 
 namespace Antidot\Persistence\Doctrine\Container;
 
+use Antidot\Persistence\Doctrine\Container\Config\ConfigProvider;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
 use Psr\Container\ContainerInterface;
+use RuntimeException;
 
 class EntityRepositoryFactory
 {
-    public function __invoke(ContainerInterface $container, string $model)
+    public function __invoke(ContainerInterface $container, string $model): ObjectRepository
     {
         $em = $container->get(EntityManagerInterface::class);
+
+        if (false === $em instanceof EntityManagerInterface) {
+            throw new RuntimeException(sprintf(
+                ConfigProvider::CONTAINER_EXCEPTION_MESSAGE_PATTER,
+                EntityManagerInterface::class
+            ));
+        }
 
         return $em->getRepository($model);
     }

--- a/test/Container/AntidotCliDoctrineDelegatorFactoryTest.php
+++ b/test/Container/AntidotCliDoctrineDelegatorFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace AntidotTest\Persistence\Doctrine\Container;
+
+use Antidot\Cli\Application\Console;
+use Antidot\Persistence\Doctrine\Container\AntidotCliDoctrineDelegatorFactory;
+use Antidot\Persistence\Doctrine\Container\Config\ConfigProvider;
+use Closure;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class AntidotCliDoctrineDelegatorFactoryTest extends TestCase
+{
+    /** @var AntidotCliDoctrineDelegatorFactory */
+    private AntidotCliDoctrineDelegatorFactory $factory;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|ContainerInterface */
+    private $container;
+    /** @var Console|\PHPUnit\Framework\MockObject\MockObject */
+    private $console;
+    private Closure $callbackFunction;
+    private string $servicename;
+    /** @var EntityManagerInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $entityManager;
+
+    public function setUp(): void
+    {
+        $this->servicename = sprintf(
+            ConfigProvider::CONNECTION_ALIAS_PATTERN,
+            ConfigProvider::DEFAULT_CONNECTION
+        );
+        $this->console = new Console();
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->factory = new AntidotCliDoctrineDelegatorFactory();
+        $this->callbackFunction = fn() => $this->console;
+    }
+
+    public function testItShouldReturnADecoratedInstanceOfConsole(): void
+    {
+        $this->entityManager->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($this->createMock(Connection::class));
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with($this->servicename)
+            ->willReturn($this->entityManager);
+
+        $this->factory->__invoke($this->container, '', $this->callbackFunction);
+    }
+}

--- a/test/Container/DoctrineCliHelperSetFactoryTest.php
+++ b/test/Container/DoctrineCliHelperSetFactoryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace AntidotTest\Persistence\Doctrine\Container;
+
+use Antidot\Persistence\Doctrine\Container\Config\ConfigProvider;
+use Antidot\Persistence\Doctrine\Container\DoctrineCliHelperSetFactory;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+class DoctrineCliHelperSetFactoryTest extends TestCase
+{
+    private const CUSTOM_CONNECTION_NAME = 'custom_conn';
+
+    /** @var \PHPUnit\Framework\MockObject\MockObject|ContainerInterface */
+    private $container;
+    /** @var DoctrineCliHelperSetFactory */
+    private DoctrineCliHelperSetFactory $factory;
+    /** @var EntityManagerInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $entityManager;
+    private string $servicename;
+    private string $customServicename;
+
+    public function setUp(): void
+    {
+        $this->servicename = sprintf(
+            ConfigProvider::CONNECTION_ALIAS_PATTERN,
+            ConfigProvider::DEFAULT_CONNECTION
+        );
+        $this->customServicename = sprintf(
+            ConfigProvider::CONNECTION_ALIAS_PATTERN,
+            self::CUSTOM_CONNECTION_NAME
+        );
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->factory = new DoctrineCliHelperSetFactory();
+    }
+
+    public function testItShouldReturnAnInstanceOfDoctrineConsoleRunner(): void
+    {
+        $this->entityManager->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($this->createMock(Connection::class));
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with($this->servicename)
+            ->willReturn($this->entityManager);
+
+        $this->factory->__invoke($this->container);
+    }
+
+    public function testItShouldReturnAnInstanceOfDoctrineConsoleRunnerWithDifferentConnections(): void
+    {
+        $this->entityManager->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($this->createMock(Connection::class));
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with($this->customServicename)
+            ->willReturn($this->entityManager);
+
+        $this->factory->__invoke($this->container, self::CUSTOM_CONNECTION_NAME);
+    }
+
+    public function testItShouldThrowAnExceptionWhenEntityManagerIsNotPresentInTheDIContainer(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            ConfigProvider::CONTAINER_EXCEPTION_MESSAGE_PATTER,
+            EntityManagerInterface::class
+        ));
+        $this->factory->__invoke($this->container);
+    }
+}

--- a/test/Container/EntityRepositoryFactoryTest.php
+++ b/test/Container/EntityRepositoryFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace AntidotTest\Persistence\Doctrine\Container;
+
+use Antidot\Persistence\Doctrine\Container\Config\ConfigProvider;
+use Antidot\Persistence\Doctrine\Container\EntityRepositoryFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+class EntityRepositoryFactoryTest extends TestCase
+{
+    private const ENTITY_CLASS = 'Some\Entity';
+    /** @var EntityManagerInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $entityManager;
+    /** @var \PHPUnit\Framework\MockObject\MockObject|ContainerInterface */
+    private $container;
+    /** @var EntityRepositoryFactory */
+    private EntityRepositoryFactory $factory;
+
+    public function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->factory = new EntityRepositoryFactory();
+    }
+
+    public function testItShouldThrowAnExceptionWhenEntityManagerIsNotPresentInTheDIContainer(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            ConfigProvider::CONTAINER_EXCEPTION_MESSAGE_PATTER,
+            EntityManagerInterface::class
+        ));
+        $this->factory->__invoke($this->container, self::ENTITY_CLASS);
+    }
+
+    public function testItShouldCreatANewInstancesOfObjectRepository(): void
+    {
+        $this->entityManager->expects($this->once())
+            ->method('getRepository')
+            ->with(self::ENTITY_CLASS)
+            ->willReturn($this->createMock(ObjectRepository::class));
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with(EntityManagerInterface::class)
+            ->willReturn($this->entityManager);
+
+        $this->factory->__invoke($this->container, self::ENTITY_CLASS);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Update composer minimum PHP version to PHP 7.4.3
* Add missing dependency "doctrine/migrations"
* Remove deprecated commands from Antidot CLI command autoloader config
* Replace deprecated DASPRiD/container-interop-doctrine in favor of Roave/psr-container-doctrine https://github.com/antidot-framework/doctrine/issues/1 

## Motivation and context

The package was outdated from the current versión of the Antidot framework, and it is using deprecated libraries.
 
## How has this been tested?

[WIP]

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

